### PR TITLE
Try making travis build rpms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
   - pip install coveralls coverage
 
   # And install tools to be able to build RPMs
-  - apt-get -qq install rpm
+  - sudo apt-get -qq install rpm
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,9 @@ install:
   # to coveralls.
   - pip install coveralls coverage
 
+  # And install tools to be able to build RPMs
+  - apt-get -qq install rpm
+
 script:
   - |
     if [[ "${OPENSSL}" == "0.9.8" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ script:
   - |
     pip install -e .
   - |
-    coverage run --branch --source=OpenSSL setup.py bdist_wheel test
+    coverage run --branch --source=OpenSSL setup.py bdist_wheel bdist_rpm test
   - |
     coverage report -m
   - |

--- a/rpm/build_script
+++ b/rpm/build_script
@@ -1,1 +1,1 @@
-make -C doc text ps html
+make -C man text html

--- a/rpm/build_script
+++ b/rpm/build_script
@@ -1,1 +1,1 @@
-make -C doc man text html
+make -C doc text html

--- a/rpm/build_script
+++ b/rpm/build_script
@@ -1,1 +1,1 @@
-make -C man text html
+make -C doc man text html


### PR DESCRIPTION
Some minimal steps towards building RPMs on travis.

This doesn't actually work.  You can see the latest failures at https://travis-ci.org/exarkun/pyopenssl/jobs/47534352

I think some further changes are probably merited in setup.cfg (it's not clear to me that the build-requires declared there is actually correct, for example).
